### PR TITLE
Replace "WHITELISTED" by "ALLOWLISTED" in all environment variables.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         config:
         # [Python version, tox env]
-        - ["3.7",  "py37-plone52"]
         - ["3.8",  "py38-plone52"]
         - ["3.8",  "py38-plone60"]
         - ["3.12",  "py312-plone60"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,7 @@ jobs:
         - ["3.7",  "py37-plone52"]
         - ["3.8",  "py38-plone52"]
         - ["3.8",  "py38-plone60"]
-        - ["3.9",  "py39-plone60"]
-        - ["3.10",  "py310-plone60"]
+        - ["3.12",  "py312-plone60"]
     name: ${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-2.2 (unreleasd)
----------------
+3.0.0 (unreleased)
+------------------
 
 - Replace "WHITELISTED" by "ALLOWLISTED" in all environment variables.
   The old spelling is still checked as well for backwards compatibility.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Changelog
   Fixes `issue 20 <https://github.com/collective/collective.honeypot/issues/20>`_.
   [maurits]
 
-- Drop support for Python older than 3.7.  [maurits]
+- Drop support for Python older than 3.8.  [maurits]
 
 - Add Plone 6.0 and 6.1 override for ``plone.app.z3cform.templates.macros.pt``.
   [szakitibi, maurits]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 2.2 (unreleasd)
 ---------------
 
+- Replace "WHITELISTED" by "ALLOWLISTED" in all environment variables.
+  The old spelling is still checked as well for backwards compatibility.
+  Fixes `issue 20 <https://github.com/collective/collective.honeypot/issues/20>`_.
+  [maurits]
+
 - Drop support for Python older than 3.7.  [maurits]
 
 - Add Plone 6.0 and 6.1 override for ``plone.app.z3cform.templates.macros.pt``.
@@ -84,7 +89,7 @@ Changelog
 
 - First official public release.
 
-- Add kssValidateField to the default WHITELIST_ACTIONS to suppress kss inline
+- Add kssValidateField to the default ALLOWLISTED_ACTIONS to suppress kss inline
   validation being logged on Plone <= 4.2 .
   [fredvd]
 
@@ -103,7 +108,7 @@ Changelog
 0.6 (2014-04-17)
 ----------------
 
-- Whitelist edit forms by default.
+- Allow edit forms by default.
   [maurits]
 
 - Log when we load patches and add extra protected actions.
@@ -116,7 +121,7 @@ Changelog
 - Support disallowing all posts.
   [maurits]
 
-- Support checking start strings for white listed actions.
+- Support checking start strings for allowed actions.
   [maurits]
 
 - Allow configuring log levels.

--- a/README.rst
+++ b/README.rst
@@ -170,8 +170,8 @@ and it will get picked up.  But the usual way would be to do this in
   environment-vars =
       HONEYPOT_FIELD pooh
       EXTRA_PROTECTED_ACTIONS discussion_reply join_form sendto_form
-      WHITELISTED_ACTIONS jq_reveal_email
-      WHITELISTED_START jq_*
+      ALLOWLISTED_ACTIONS jq_reveal_email
+      ALLOWLISTED_START jq_*
       IGNORED_FORM_FIELDS secret_field
       ACCEPTED_LOG_LEVEL info
       SPAMMER_LOG_LEVEL error
@@ -208,13 +208,13 @@ EXTRA_PROTECTED_ACTIONS
     you can add it here and it will stop functioning.  For ``@@view``
     simply use ``view`` and it will match both.
 
-WHITELISTED_ACTIONS
+ALLOWLISTED_ACTIONS
     These form actions are not checked.  List here actions that are
     harmless, for example actions that load some data via an AJAX
     call.  Generally, actions that change nothing in the database and
     do not send emails are safe to add here.  If you add this
     environment variable but leave it empty, you override the
-    default and do not whitelist anything.  By default we whitelist
+    default and do not allow anything.  By default we allow
     these actions:
 
     - ``at_validate_field`` (inline validation)
@@ -231,9 +231,9 @@ WHITELISTED_ACTIONS
 
 
 
-WHITELISTED_START
+ALLOWLISTED_START
     Form actions starting with one of these strings are not checked.
-    See ``WHITELISTED_ACTIONS`` for more info.  If you have lots of
+    See ``ALLOWLISTED_ACTIONS`` for more info.  If you have lots of
     harmless actions that start with ``jq_`` you can add that string
     to this list.  Regular expression are too easy to get wrong, so we
     do not support it.

--- a/base.cfg
+++ b/base.cfg
@@ -25,7 +25,7 @@ eggs =
 environment-vars +=
 #    HONEYPOT_FIELD pooh
     EXTRA_PROTECTED_ACTIONS discussion_reply join_form sendto_form contact-info send_feedback_site register
-    WHITELISTED_ACTIONS jq_reveal_email z3cform_validate_field
+    ALLOWLISTED_ACTIONS jq_reveal_email z3cform_validate_field
     IGNORED_FORM_FIELDS secret_field
 
 

--- a/collective/honeypot/config.py
+++ b/collective/honeypot/config.py
@@ -7,6 +7,16 @@ logger = logging.getLogger("collective.honeypot")
 
 def get_multi(key, default):
     value = os.environ.get(key, None)
+    if value is None and "ALLOWLISTED" in key:
+        # Fall back to old name.
+        old_key = key.replace("ALLOWLISTED", "WHITELISTED")
+        value = os.environ.get(old_key, None)
+        if value:
+            logger.info(
+                "Found environment variable %s. You can use %s.",
+                old_key,
+                key
+            )
     if value is None:
         return set(default)
     value = value.strip().replace(",", " ").replace("@", " ")
@@ -28,8 +38,8 @@ EXTRA_PROTECTED_ACTIONS = get_multi("EXTRA_PROTECTED_ACTIONS", ())
 logger.info("Extra protected actions: %r", EXTRA_PROTECTED_ACTIONS)
 
 # Actions that are not checked:
-WHITELISTED_ACTIONS = get_multi(
-    "WHITELISTED_ACTIONS",
+ALLOWLISTED_ACTIONS = get_multi(
+    "ALLOWLISTED_ACTIONS",
     (
         "at_validate_field",
         "atct_edit",
@@ -39,11 +49,11 @@ WHITELISTED_ACTIONS = get_multi(
         "z3cform_validate_field",
     ),
 )
-logger.info("Whitelisted actions: %r", WHITELISTED_ACTIONS)
+logger.info("Allowed actions: %r", ALLOWLISTED_ACTIONS)
 # Actions starting with these strings are not checked.  Note: regular
 # expressions are too easily done wrong, so we do not support them.
-WHITELISTED_START = get_multi("WHITELISTED_START", ())
-logger.info("Whitelisted action start strings: %r", WHITELISTED_START)
+ALLOWLISTED_START = get_multi("ALLOWLISTED_START", ())
+logger.info("Allowed action start strings: %r", ALLOWLISTED_START)
 
 # Fields that are not logged:
 IGNORED_FORM_FIELDS = get_multi("IGNORED_FORM_FIELDS", ())
@@ -77,7 +87,7 @@ logger.info("Accepted log level: %r", ACCEPTED_LOG_LEVEL)
 SPAMMER_LOG_LEVEL = get_log_level("SPAMMER_LOG_LEVEL", logging.ERROR)
 logger.info("Spammer log level: %r", SPAMMER_LOG_LEVEL)
 
-# Disallow all posts, even whitelisted ones.
+# Disallow all posts, even allowlisted ones.
 DISALLOW_ALL_POSTS = os.environ.get("DISALLOW_ALL_POSTS", "")
 if DISALLOW_ALL_POSTS and DISALLOW_ALL_POSTS.lower() in ["1", "on", "true", "yes"]:
     DISALLOW_ALL_POSTS = True

--- a/collective/honeypot/testing.py
+++ b/collective/honeypot/testing.py
@@ -16,11 +16,11 @@ from zope.component import queryUtility
 import collective.honeypot.config
 import plone.restapi
 
-# We want WHITELISTED_START to be empty by default currently, but we
+# We want ALLOWLISTED_START to be empty by default currently, but we
 # do want to test it.
-start = list(collective.honeypot.config.WHITELISTED_START)
+start = list(collective.honeypot.config.ALLOWLISTED_START)
 start.append("jq_")
-collective.honeypot.config.WHITELISTED_START = set(start)
+collective.honeypot.config.ALLOWLISTED_START = set(start)
 
 
 def patch_mailhost(portal):

--- a/collective/honeypot/tests/test_unit.py
+++ b/collective/honeypot/tests/test_unit.py
@@ -5,7 +5,7 @@ from collective.honeypot.config import HONEYPOT_FIELD
 from collective.honeypot.utils import check_post
 from collective.honeypot.utils import found_honeypot
 from collective.honeypot.utils import get_form
-from collective.honeypot.utils import whitelisted
+from collective.honeypot.utils import allowlisted
 from Testing import makerequest
 from zExceptions import Forbidden
 from zope.publisher.browser import TestRequest
@@ -83,16 +83,16 @@ class UtilsTestCase(unittest.TestCase):
         request = self._request(dest="/join_form", form={HONEYPOT_FIELD: ""})
         self.assertEqual(check_post(self._request()), None)
 
-    def test_whitelisted(self):
-        self.assertEqual(whitelisted(""), False)
-        self.assertEqual(whitelisted("random"), False)
-        self.assertEqual(whitelisted("jq_reveal_email"), True)
-        self.assertEqual(whitelisted("at_validate_field"), True)
-        self.assertEqual(whitelisted("z3cform_validate_field"), True)
+    def test_allowlisted(self):
+        self.assertEqual(allowlisted(""), False)
+        self.assertEqual(allowlisted("random"), False)
+        self.assertEqual(allowlisted("jq_reveal_email"), True)
+        self.assertEqual(allowlisted("at_validate_field"), True)
+        self.assertEqual(allowlisted("z3cform_validate_field"), True)
         # Various jquery methods may use this.  Note: the next test fails when
         # run on its own, because testing.py is not loaded.  But 'bin/test -u'
         # should work fine.
-        self.assertEqual(whitelisted("jq_"), True)
-        self.assertEqual(whitelisted("jq"), False)
-        self.assertEqual(whitelisted("jq_foo_bar"), True)
-        self.assertEqual(whitelisted("foo_jq_"), False)
+        self.assertEqual(allowlisted("jq_"), True)
+        self.assertEqual(allowlisted("jq"), False)
+        self.assertEqual(allowlisted("jq_foo_bar"), True)
+        self.assertEqual(allowlisted("foo_jq_"), False)

--- a/collective/honeypot/utils.py
+++ b/collective/honeypot/utils.py
@@ -5,8 +5,8 @@ from collective.honeypot.config import EXTRA_PROTECTED_ACTIONS
 from collective.honeypot.config import HONEYPOT_FIELD
 from collective.honeypot.config import IGNORED_FORM_FIELDS
 from collective.honeypot.config import SPAMMER_LOG_LEVEL
-from collective.honeypot.config import WHITELISTED_ACTIONS
-from collective.honeypot.config import WHITELISTED_START
+from collective.honeypot.config import ALLOWLISTED_ACTIONS
+from collective.honeypot.config import ALLOWLISTED_START
 from copy import deepcopy
 from zExceptions import Forbidden
 from zope.globalrequest import getRequest
@@ -70,12 +70,12 @@ def deny(msg=None):
     raise Forbidden(msg)
 
 
-def whitelisted(action):
-    if action in WHITELISTED_ACTIONS:
+def allowlisted(action):
+    if action in ALLOWLISTED_ACTIONS:
         return True
     # Check action start strings.
-    for white in WHITELISTED_START:
-        if action.startswith(white):
+    for allow in ALLOWLISTED_START:
+        if action.startswith(allow):
             return True
     return False
 
@@ -146,8 +146,8 @@ def check_post(request):
     action = url.split("/")[-1]  # last part of url
     action = action.lstrip("@")
 
-    if whitelisted(action):
-        logger.debug("Action whitelisted: %s.", action)
+    if allowlisted(action):
+        logger.debug("Action allowlisted: %s.", action)
         return
     form = get_form(request)
     if action in EXTRA_PROTECTED_ACTIONS:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pip==24.0
-setuptools==65.0.2
+setuptools==69.5.1
 wheel==0.43.0
 zc.buildout==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pip==24.0
-setuptools==69.5.1
+setuptools==65.0.2
 wheel==0.43.0
 zc.buildout==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,4 @@
-# With pip>=22.2, buildout fails to check the python-requires of a package,
-# so you may get incompatible versions.
-# See https://github.com/buildout/buildout/issues/613
-# So we pin an older one.
-pip==22.1.2
-setuptools==65.4.1
-wheel==0.37.1
-zc.buildout==3.0.0rc3
-
-# Windows specific down here (has to be installed here, fails in buildout)
-# Dependency of zope.sendmail:
-pywin32 ; platform_system == 'Windows'
-# SSL Certs on Windows, because Python is missing them otherwise:
-certifi ; platform_system == 'Windows'
-# Dependency of collective.recipe.omelette:
-ntfsutils ; platform_system == 'Windows' and python_version < '3.0'
+pip==24.0
+setuptools==69.5.1
+wheel==0.43.0
+zc.buildout==3.0.1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="collective.honeypot",
-    version="2.2.dev0",
+    version="3.0.0dev0",
     description="Anti-spam honeypot for Plone",
     long_description=(open("README.rst").read() + "\n" + open("CHANGES.rst").read()),
     # Get more strings from https://pypi.org/classifiers

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{37,38}-plone52,
-    py{38,39,310}-plone60,
+    py{38,312}-plone60,
 skip_missing_interpreters = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38}-plone52,
+    py38-plone52,
     py{38,312}-plone60,
 skip_missing_interpreters = True
 


### PR DESCRIPTION
The old spelling is still checked as well for backwards compatibility.

Fixes issue #20.