### PR TITLE
Change the default ACCEPTED_LOG_LEVEL to DEBUG

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 - Drop support for Plone 5.2 and Python 3.8.  [maurits]
 
+- Change the default ``ACCEPTED_LOG_LEVEL`` to DEBUG. [davisagli]
+
 
 3.0.0 (2024-06-18)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -251,7 +251,7 @@ ACCEPTED_LOG_LEVEL
     Log level for accepted posts.  This accepts standard lower or
     upper case log levels: debug, info, warn, warning, error,
     critical.  When an unknown level is used or the setting is empty,
-    we fall back to the default: ``INFO``.
+    we fall back to the default: ``DEBUG``.
 
 SPAMMER_LOG_LEVEL
     Log level for caught spammers.  This accepts standard lower or

--- a/collective/honeypot/config.py
+++ b/collective/honeypot/config.py
@@ -81,7 +81,7 @@ def get_log_level(key, default):
 
 
 # Log level for accepted posts.
-ACCEPTED_LOG_LEVEL = get_log_level("ACCEPTED_LOG_LEVEL", logging.INFO)
+ACCEPTED_LOG_LEVEL = get_log_level("ACCEPTED_LOG_LEVEL", logging.DEBUG)
 logger.info("Accepted log level: %r", ACCEPTED_LOG_LEVEL)
 # Log level for caught spammers.
 SPAMMER_LOG_LEVEL = get_log_level("SPAMMER_LOG_LEVEL", logging.ERROR)


### PR DESCRIPTION
To avoid logging sensitive data by default. Fixes #29 